### PR TITLE
perf : 입사 현황 조회 페이지 성능 개선

### DIFF
--- a/src/main/java/org/example/bumitori_server/dto/CheckInResponseDto.java
+++ b/src/main/java/org/example/bumitori_server/dto/CheckInResponseDto.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 public class CheckInResponseDto {
-    private String email;
     private String name;
     private String roomId;
     private Gender gender;

--- a/src/main/java/org/example/bumitori_server/repository/CheckInRepository.java
+++ b/src/main/java/org/example/bumitori_server/repository/CheckInRepository.java
@@ -3,8 +3,12 @@ package org.example.bumitori_server.repository;
 import org.example.bumitori_server.entity.CheckIn;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CheckInRepository extends JpaRepository<CheckIn, Long> {
-    Optional<CheckIn> findByUserId(Long userId);
+  Optional<CheckIn> findByUserId(Long userId);
+
+  List<CheckIn> findByUserIdIn(List<Long> userIds);
 }
+

--- a/src/main/java/org/example/bumitori_server/repository/UserRepository.java
+++ b/src/main/java/org/example/bumitori_server/repository/UserRepository.java
@@ -7,8 +7,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
   Optional<UserEntity> findByRfid(String rfid);
-  Optional<UserEntity> findByEmail(String email);
   Optional<UserEntity> findByUserId(Long userId);
+
 }
 
 


### PR DESCRIPTION
변경 사항
--
- 기존 코드
  -  기숙사 입사 기록 조회 시 CheckIn 정보를 개별 조회해서 N+1 문제가 발생

- 변경된 코드
  - 쿼리를 한 번만 실행하여(findByUserIdIn) 모든 CheckIn 정보를 가져옴
  - Map 변환을 통해 O(1) 속도로 사용자별 CheckIn 데이터 조회

- 변경 효과
  - N+1 문제로 인해 속도가 느려지는 문제 해결
  - 기숙사 입사 기록 조회 시 응답 속도 개선